### PR TITLE
Added the functionality of making navbar logo change according to dark/light theme

### DIFF
--- a/contributors/index.html
+++ b/contributors/index.html
@@ -25,7 +25,7 @@
   <nav class="navbar navbar-dark bg-dark">
     <div class="container">
       <a class="text-light d-flex flex-row align-items-center navbar-brand" href="#">
-        <img src="src/H22/H22-logo-dark.png" alt="" height="40" class="d-inline-block align-text-top navlogo" />&nbsp;
+        <img id="H22-image" src="src/H22/H22-logo-dark.png" alt="" height="40" class="d-inline-block align-text-top navlogo" />&nbsp;
         Hacktoberfest-2022
       </a>
       <ul class="d-flex flex-row align-items-center nav navbar-nav navbar-right">

--- a/contributors/src/dark-mode-switch.min.js
+++ b/contributors/src/dark-mode-switch.min.js
@@ -6,30 +6,32 @@ function initTheme() {
   const e =
     null != localStorage.getItem("darkSwitch") &&
     "dark" == localStorage.getItem("darkSwitch");
-   if(darkSwitch.checked = e)
-      {
-        document.body.setAttribute("data-theme", "dark")
-      }
-      else{
-        document.body.removeAttribute("data-theme");
-      } 
+  if (darkSwitch.checked = e) {
+    document.body.setAttribute("data-theme", "dark")
+    document.getElementById("H22-image").src = "src/H22/H22-logo-dark.png";
+  }
+  else {
+    document.body.removeAttribute("data-theme");
+    document.getElementById("H22-image").src = "src/H22/H22-logo-light.png";
+
+  }
 }
 
 function resetTheme() {
-  
- if(darkSwitch.checked) 
-    {
-      (document.body.setAttribute("data-theme", "dark"),
-      localStorage.setItem("darkSwitch", "dark"))
 
-      text.innerHTML="Light Theme 🌤️";
-    } 
-    else {
-      (document.body.removeAttribute("data-theme"),
+  if (darkSwitch.checked) {
+    (document.body.setAttribute("data-theme", "dark"),
+      localStorage.setItem("darkSwitch", "dark"))
+    text.innerHTML = "Light Theme 🌤️";
+    document.getElementById("H22-image").src = "src/H22/H22-logo-dark.png";
+  }
+  else {
+    (document.body.removeAttribute("data-theme"),
       localStorage.removeItem("darkSwitch"));
-      text.innerHTML='Dark Theme 🌚';
-    }
-     
+    text.innerHTML = 'Dark Theme 🌚';
+    document.getElementById("H22-image").src = "src/H22/H22-logo-light.png";
+  }
+
 }
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
Added the functionality of making navbar logo change according to dark/light theme

## PR Title
The purpose of this Pull Request is to fix #1 

## Description
This fix will ensure that whenever a user clicks on toggle button of theme the logo will change accordingly.

## How you solved
To Solve this problem I use JavaScript DOM to toggle the images between modes. Whenever a person clicks on toggle button of theme then the source of the logo image will be changed.
### Screenshots



https://user-images.githubusercontent.com/78460491/196698246-a09ed583-97ec-4c7b-b046-c2425c6ae991.mp4



  

##  Checklist
- [x] I have Made this contribution as per the CONTRIBUTING guide in this repo
- [x] I have tested in local Environment.
- [x] I have made the fix as per issue conversation

